### PR TITLE
Ensure validation loaders use non-augmented transforms

### DIFF
--- a/Mira/main.py
+++ b/Mira/main.py
@@ -139,27 +139,31 @@ def train_epoch(epoch: int, model, loader, criterion,
 # ────────────────────────────────────────────────────────────────────────
 # 4.  Data loaders
 # ────────────────────────────────────────────────────────────────────────
-def build_loaders(args, ds: HAM10000Dataset, fold: int = 0):
+def build_loaders(args, ds_train: HAM10000Dataset,
+                  ds_eval: HAM10000Dataset, fold: int = 0):
     sgkf = StratifiedGroupKFold(n_splits=5, shuffle=True, random_state=42)
-    y = ds.df["dx"]
-    groups = ds.df["lesion_id"].fillna(ds.df["image_id"])
-    train_idx, test_idx = list(sgkf.split(np.zeros(len(ds)), y, groups))[fold]
-    train_df = ds.df.iloc[train_idx].reset_index(drop=True)
-    test_df  = ds.df.iloc[test_idx].reset_index(drop=True)
+    y = ds_train.df["dx"]
+    groups = ds_train.df["lesion_id"].fillna(ds_train.df["image_id"])
+    train_idx, test_idx = list(
+        sgkf.split(np.zeros(len(ds_train)), y, groups))[fold]
+    train_df = ds_train.df.iloc[train_idx].reset_index(drop=True)
+    test_df = ds_train.df.iloc[test_idx].reset_index(drop=True)
 
     val_mask = train_df.groupby("dx").sample(frac=0.2, random_state=42).index
     val_df = train_df.loc[val_mask].reset_index(drop=True)
     train_df = train_df.drop(val_mask).reset_index(drop=True)
 
-    def subset(df_slice):
-        return Subset(ds, df_slice.index.to_numpy())
+    train_ds = Subset(ds_train, train_df.index.to_numpy())
+    val_ds = Subset(ds_eval, val_df.index.to_numpy())
+    test_ds = Subset(ds_eval, test_df.index.to_numpy())
 
-    train_ds, val_ds, test_ds = map(subset, (train_df, val_df, test_df))
-
-    class_counts = train_df["dx"].value_counts().reindex(ds.classes, fill_value=0).to_numpy()
-    weights = 1. / class_counts
-    sample_weights = [weights[ds.class_to_idx[lbl]] for lbl in train_df["dx"]]
-    sampler = WeightedRandomSampler(sample_weights, len(sample_weights), replacement=True)
+    class_counts = train_df["dx"].value_counts().reindex(ds_train.classes,
+                                                          fill_value=0).to_numpy()
+    weights = 1.0 / class_counts
+    sample_weights = [weights[ds_train.class_to_idx[lbl]]
+                      for lbl in train_df["dx"]]
+    sampler = WeightedRandomSampler(sample_weights, len(sample_weights),
+                                    replacement=True)
 
     mk_loader = lambda d, shuffle=False, sampler=None: DataLoader(
         d, batch_size=args.batch_size, num_workers=args.workers,
@@ -213,8 +217,9 @@ def main(argv: List[str] | None = None) -> None:
     ])
 
     ds_train = HAM10000Dataset(args.metadata, args.images_dir, transform=train_tf)
-    ds_eval  = HAM10000Dataset(args.metadata, args.images_dir, transform=eval_tf)
-    train_loader, val_loader, test_loader = build_loaders(args, ds_train)
+    ds_eval = HAM10000Dataset(args.metadata, args.images_dir, transform=eval_tf)
+    train_loader, val_loader, test_loader = build_loaders(
+        args, ds_train, ds_eval)
 
     # model
     if args.model == "resnet18":


### PR DESCRIPTION
## Summary
- Allow `build_loaders` to accept separate training and evaluation datasets.
- Use training dataset for train split and evaluation dataset for validation/test splits.
- Update main entry to pass both datasets when constructing loaders.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b9f8f4dc8330b32dbe4f071e99dc