### PR TITLE
Fix dataset splitting to preserve indices

### DIFF
--- a/Mira/main.py
+++ b/Mira/main.py
@@ -147,17 +147,9 @@ def build_loaders(args, ds_train: HAM10000Dataset,
     groups = ds_train.df["lesion_id"].fillna(ds_train.df["image_id"])
     train_idx, test_idx = list(
         sgkf.split(np.zeros(len(ds_train)), y, groups))[fold]
-    train_df = ds_train.df.iloc[train_idx].reset_index(drop=True)
-    test_df = ds_train.df.iloc[test_idx].reset_index(drop=True)
-
-
-    y = ds.df["dx"]
-    groups = ds.df["lesion_id"].fillna(ds.df["image_id"])
-    train_idx, test_idx = list(sgkf.split(np.zeros(len(ds)), y, groups))[fold]
-    # Keep original indices so Subset points to the correct rows in ds.df
-    train_df = ds.df.iloc[train_idx]
-    test_df = ds.df.iloc[test_idx]
-
+    # Keep original indices so Subset points to the correct rows in ds_train.df
+    train_df = ds_train.df.iloc[train_idx]
+    test_df = ds_train.df.iloc[test_idx]
 
 
     val_mask = train_df.groupby("dx").sample(frac=0.2, random_state=42).index
@@ -168,18 +160,6 @@ def build_loaders(args, ds_train: HAM10000Dataset,
     train_ds = Subset(ds_train, train_df.index.to_numpy())
     val_ds = Subset(ds_eval, val_df.index.to_numpy())
     test_ds = Subset(ds_eval, test_df.index.to_numpy())
-
-
-
-    train_ds = Subset(ds_train, train_df.index.to_numpy())
-    val_ds = Subset(ds_eval, val_df.index.to_numpy())
-    test_ds = Subset(ds_eval, test_df.index.to_numpy())
-
-    def subset(df_slice: pd.DataFrame) -> Subset:
-        """Return a view of ``ds`` for the rows in ``df_slice``."""
-        return Subset(ds, df_slice.index.to_numpy())
-
-
 
     class_counts = train_df["dx"].value_counts().reindex(ds_train.classes,
                                                           fill_value=0).to_numpy()


### PR DESCRIPTION
## Summary
- remove redundant ds-based split and preserve original indices for subsets
- create train/val/test subsets from correct datasets using those indices

## Testing
- `python -m py_compile Mira/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892be9e08288330a2041dd0abbd8f90